### PR TITLE
Heroku crashes

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,0 +1,2 @@
+https://github.com/heroku/heroku-buildpack-nodejs.git
+https://github.com/heroku/heroku-buildpack-python.git

--- a/main.py
+++ b/main.py
@@ -30,7 +30,7 @@ from nxtbus_stops import NxtbusStops
 define("host", default="localhost", help="app host (domain)", type=str)
 define("production",default=0, help="1 if in production, 0 if local", type=int)
 
-port = os.environ.get("PORT", 5000) # 5000 is Heroku's default port
+port = 5000 #os.environ.get("PORT", 5000) # 5000 is Heroku's default port
 
 class Application(tornado.web.Application):
 	def __init__(self):

--- a/main.py
+++ b/main.py
@@ -30,7 +30,7 @@ from nxtbus_stops import NxtbusStops
 define("host", default="localhost", help="app host (domain)", type=str)
 define("production",default=0, help="1 if in production, 0 if local", type=int)
 
-port = 5000 #os.environ.get("PORT", 5000) # 5000 is Heroku's default port
+port = os.environ.get("PORT", 5000) # 5000 is Heroku's default port
 
 class Application(tornado.web.Application):
 	def __init__(self):

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "",
   "main": "main.py",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
     "postinstall": "gulp default"
   },
   "repository": {


### PR DESCRIPTION
Removed empty test and added multi-buildpack support so that Heroku correctly installs Python Pip dependancies as well as runs Node's postinstall.
